### PR TITLE
API simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ And add `sri` to your `INSTALLED_APPS`.
 ```html
 {% load sri %}
 
-{% sri "index.js" %} <!-- Will output "<script src='/static/index.js' integrity='sha256-...'></script>" -->
-{% sri "index.css" %} <!-- Will output "<link rel='stylesheet' href='/static/index.css' integrity='sha256-...'/>" -->
+{% sri_static "index.js" %} <!-- Will output "<script src='/static/index.js' integrity='sha256-...'></script>" -->
+{% sri_static "index.css" %} <!-- Will output "<link rel='stylesheet' href='/static/index.css' integrity='sha256-...'/>" -->
 ```
 
 For performance, the hashes of files are cached in memory using [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache) for future requests.
@@ -42,7 +42,7 @@ The SRI standard supports 3 algorithms: sha256, sha384 and sha512. By default, S
 ```html
 {% load sri %}
 
-{% sri "index.js" "sha512" %} <!-- Will output "<script src='/static/index.js' integrity='sha512-...'></script>" -->
+{% sri_static "index.js" "sha512" %} <!-- Will output "<script src='/static/index.js' integrity='sha512-...'></script>" -->
 ```
 
 The default algorithm can be changed by setting `SRI_ALGORITHM` to the required algorithm.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ To retrieve just the integrity hash (the contents of the `integrity` attribute),
 {% sri_integrity_static "index.js" "sha512" %} <!-- Will output "sha512-..." -->
 ```
 
+#### Supported Files
+
+For automatic tag output, the following files are supported:
+
+- `.js`
+- `.css`
+
+`sri_integrity_static` is unaffected by this limitation.
+
 ### API
 
 ```python

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ The default algorithm can be changed by setting `SRI_ALGORITHM` to the required 
 
 To retrieve just the integrity hash (the contents of the `integrity` attribute), you can use the `{% sri_integrity_static %}` tag, which supports the same arguments as the other tags.
 
+```html
+{% load sri %}
+
+{% sri_integrity_static "index.js" "sha512" %} <!-- Will output "sha512-..." -->
+```
+
 ### API
 
 ```python

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The default algorithm can be changed by setting `SRI_ALGORITHM` to the required 
 
 #### Just the integrity value
 
-To retrieve just the integrity hash (the contents of the `integrity` attribute), you can use the `{% sri_integrity %}` tag, which supports the same arguments as the other tags.
+To retrieve just the integrity hash (the contents of the `integrity` attribute), you can use the `{% sri_integrity_static %}` tag, which supports the same arguments as the other tags.
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ And add `sri` to your `INSTALLED_APPS`.
 
 ## Usage
 
-`django-sri` is designed to be used through template tags:
+### Template Tags
+
+`django-sri` is designed to primarily be used through template tags:
 
 ```html
 {% load sri %}
@@ -29,20 +31,11 @@ And add `sri` to your `INSTALLED_APPS`.
 {% sri "index.css" %} <!-- Will output "<link rel='stylesheet' href='/static/index.css' integrity='sha256-...'/>" -->
 ```
 
-Specific tags are also available:
-
-```html
-{% load sri %}
-
-{% sri_js "index.js" %} <!-- Will output "<script src='/static/index.js' integrity='sha256-...'></script>" -->
-{% sri_css "index.css" %} <!-- Will output "<link rel='stylesheet' href='/static/index.css' integrity='sha256-...'/>" -->
-```
-
 For performance, the hashes of files are cached in memory using [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache) for future requests.
 
 __Note__: By default, integrity hashes are not output when `DEBUG` is `True`, as static files change a lot during local development. To override this, set `USE_SRI` to `True`.
 
-### Algorithms
+#### Algorithms
 
 The SRI standard supports 3 algorithms: sha256, sha384 and sha512. By default, SHA256 is used. To override this, supply an additional argument to the `sri` template tag (or the specific ones):
 
@@ -54,9 +47,17 @@ The SRI standard supports 3 algorithms: sha256, sha384 and sha512. By default, S
 
 The default algorithm can be changed by setting `SRI_ALGORITHM` to the required algorithm.
 
-### Just the integrity value
+#### Just the integrity value
 
 To retrieve just the integrity hash (the contents of the `integrity` attribute), you can use the `{% sri_integrity %}` tag, which supports the same arguments as the other tags.
+
+### API
+
+```python
+from sri import calculate_integrity
+
+calculate_integrity("/path/to/myfile.txt")  # "sha256-..."
+```
 
 ### _"Does this work with [whitenoise](https://whitenoise.evans.io/en/stable/) or alike?"_
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ And add `sri` to your `INSTALLED_APPS`.
 
 ### Template Tags
 
+__Note__: By default, integrity hashes are not output when `DEBUG` is `True`, as static files change a lot during local development. To override this, set `USE_SRI` to `True`.
+
 `django-sri` is designed to primarily be used through template tags:
 
 ```html
@@ -32,8 +34,6 @@ And add `sri` to your `INSTALLED_APPS`.
 ```
 
 For performance, the hashes of files are cached in memory using [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache) for future requests.
-
-__Note__: By default, integrity hashes are not output when `DEBUG` is `True`, as static files change a lot during local development. To override this, set `USE_SRI` to `True`.
 
 #### Algorithms
 

--- a/sri/__init__.py
+++ b/sri/__init__.py
@@ -1,3 +1,3 @@
-from sri.templatetags.sri import sri_integrity
+from sri.utils import calculate_integrity
 
-__all__ = ["sri_integrity"]
+__all__ = ["calculate_integrity"]

--- a/sri/templatetags/sri.py
+++ b/sri/templatetags/sri.py
@@ -1,5 +1,4 @@
 import os.path
-from collections import OrderedDict
 
 from django import template
 from django.templatetags.static import static
@@ -16,33 +15,32 @@ from sri.utils import (
 register = template.Library()
 
 
-@register.simple_tag
-def sri_js(path, algorithm=DEFAULT_ALGORITHM):
-    attrs = OrderedDict([("type", "text/javascript"), ("src", static(path))])
-    if USE_SRI:
-        attrs["integrity"] = calculate_integrity(get_static_path(path), algorithm)
-        attrs["crossorigin"] = "anonymous"
+def sri_js(attrs: dict, path: str, algorithm: str):
+    attrs.update({"type": "text/javascript", "src": static(path)})
     return mark_safe(f"<script {attrs_to_str(attrs)}></script>")
 
 
-@register.simple_tag
-def sri_css(path, algorithm=DEFAULT_ALGORITHM):
-    attrs = OrderedDict(
-        [("rel", "stylesheet"), ("type", "text/css"), ("href", static(path))]
-    )
-    if USE_SRI:
-        attrs["integrity"] = calculate_integrity(get_static_path(path), algorithm)
-        attrs["crossorigin"] = "anonymous"
-    return mark_safe(f"<link {attrs_to_str(attrs)} />")
+def sri_css(attrs: dict, path: str, algorithm: str):
+    attrs.update({"rel": "stylesheet", "type": "text/css", "href": static(path)})
+    return mark_safe(f"<link {attrs_to_str(attrs)}/>")
 
 
 EXTENSIONS = {"js": sri_js, "css": sri_css}
 
 
 @register.simple_tag
-def sri(path, algorithm=DEFAULT_ALGORITHM):
+def sri_static(path, algorithm=DEFAULT_ALGORITHM):
     extension = os.path.splitext(path)[1][1:]
-    return EXTENSIONS[extension](path, algorithm)
+    sri_method = EXTENSIONS[extension]
+    attrs = {}
+    if USE_SRI:
+        attrs.update(
+            {
+                "integrity": calculate_integrity(get_static_path(path), algorithm),
+                "crossorigin": "anonymous",
+            }
+        )
+    return sri_method(attrs, path, algorithm)
 
 
 @register.simple_tag

--- a/sri/templatetags/sri.py
+++ b/sri/templatetags/sri.py
@@ -44,5 +44,5 @@ def sri_static(path, algorithm=DEFAULT_ALGORITHM):
 
 
 @register.simple_tag
-def sri_integrity(path, algorithm=DEFAULT_ALGORITHM):
+def sri_integrity_static(path, algorithm=DEFAULT_ALGORITHM):
     return calculate_integrity(get_static_path(path), algorithm)

--- a/sri/utils.py
+++ b/sri/utils.py
@@ -20,7 +20,7 @@ def calculate_hash(path: str, algorithm: str) -> str:
     return base64.b64encode(digest).decode()
 
 
-def get_static_path(path) -> str:
+def get_static_path(path: str) -> str:
     """
     Resolves a path commonly passed to `{% static %}` into a filesystem path
     """
@@ -32,4 +32,4 @@ def calculate_integrity(path: str, algorithm: str = DEFAULT_ALGORITHM) -> str:
 
 
 def attrs_to_str(attrs: dict):
-    return " ".join(f'{k}="{v}"' for k, v in attrs.items())
+    return " ".join(f'{k}="{v}"' for k, v in sorted(attrs.items()))

--- a/tests/templates/algorithms.html
+++ b/tests/templates/algorithms.html
@@ -1,5 +1,5 @@
 {% load sri %}
 
-{% sri "index.js" "sha384" %}
+{% sri_static "index.js" "sha384" %}
 
-{% sri "index.css" "sha512" %}
+{% sri_static "index.css" "sha512" %}

--- a/tests/templates/generic.html
+++ b/tests/templates/generic.html
@@ -1,5 +1,0 @@
-{% load sri %}
-
-{% sri "index.js" %}
-
-{% sri "index.css" %}

--- a/tests/templates/simple.html
+++ b/tests/templates/simple.html
@@ -1,5 +1,5 @@
 {% load sri %}
 
-{% sri_js "index.js" %}
+{% sri_static "index.js" %}
 
-{% sri_css "index.css" %}
+{% sri_static "index.css" %}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -77,8 +77,10 @@ def test_disable_sri(file):
 
 @pytest.mark.parametrize("algorithm", utils.HASHERS.keys())
 @pytest.mark.parametrize("file", TEST_FILES)
-def test_sri_integrity(algorithm, file):
-    assert templatetags.sri_integrity(file, algorithm).startswith(f"{algorithm}-")
+def test_sri_integrity_static(algorithm, file):
+    assert templatetags.sri_integrity_static(file, algorithm).startswith(
+        f"{algorithm}-"
+    )
 
 
 @pytest.mark.parametrize("file", TEST_FILES)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,23 +10,11 @@ from sri.templatetags import sri as templatetags
 def test_simple_template():
     rendered = render_to_string("simple.html")
     assert (
-        '<script type="text/javascript" src="/static/index.js" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" crossorigin="anonymous"></script>'
+        '<script crossorigin="anonymous" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" src="/static/index.js" type="text/javascript"></script>'
         in rendered
     )
     assert (
-        '<link rel="stylesheet" type="text/css" href="/static/index.css" integrity="sha256-fsqAKvNYgo9VQgSc4rD93SiW/AjKFwLtWlPi6qviBxY=" crossorigin="anonymous" />'
-        in rendered
-    )
-
-
-def test_generic_template():
-    rendered = render_to_string("generic.html")
-    assert (
-        '<script type="text/javascript" src="/static/index.js" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" crossorigin="anonymous"></script>'
-        in rendered
-    )
-    assert (
-        '<link rel="stylesheet" type="text/css" href="/static/index.css" integrity="sha256-fsqAKvNYgo9VQgSc4rD93SiW/AjKFwLtWlPi6qviBxY=" crossorigin="anonymous" />'
+        '<link crossorigin="anonymous" href="/static/index.css" integrity="sha256-fsqAKvNYgo9VQgSc4rD93SiW/AjKFwLtWlPi6qviBxY=" rel="stylesheet" type="text/css"/>'
         in rendered
     )
 
@@ -34,48 +22,19 @@ def test_generic_template():
 def test_algorithms_template():
     rendered = render_to_string("algorithms.html")
     assert (
-        '<script type="text/javascript" src="/static/index.js" integrity="sha384-dExnf54EbXTQ1VmweBEJRWX3MPT4xeDV5p71GIX2hpvV+8B/kzo3SObynuveYt9w" crossorigin="anonymous"></script>'
+        '<script crossorigin="anonymous" integrity="sha384-dExnf54EbXTQ1VmweBEJRWX3MPT4xeDV5p71GIX2hpvV+8B/kzo3SObynuveYt9w" src="/static/index.js" type="text/javascript"></script>'
         in rendered
     )
     assert (
-        '<link rel="stylesheet" type="text/css" href="/static/index.css" integrity="sha512-7v9G7AKwpjnlEYhw9GdXu/9G8bq0PqM427/QmgH2TufqEUcjsANEoyCoOkpV8TBCnbQigwNKpMaZNskJG8Ejdw==" crossorigin="anonymous" />'
+        '<link crossorigin="anonymous" href="/static/index.css" integrity="sha512-7v9G7AKwpjnlEYhw9GdXu/9G8bq0PqM427/QmgH2TufqEUcjsANEoyCoOkpV8TBCnbQigwNKpMaZNskJG8Ejdw==" rel="stylesheet" type="text/css"/>'
         in rendered
     )
-
-
-@pytest.mark.parametrize("algorithm", utils.HASHERS.keys())
-def test_js_algorithm(algorithm):
-    assert f'integrity="{algorithm}-' in templatetags.sri_js("index.js", algorithm)
-
-
-@pytest.mark.parametrize("algorithm", utils.HASHERS.keys())
-def test_css_algorithm(algorithm):
-    assert f'integrity="{algorithm}-' in templatetags.sri_css("index.css", algorithm)
 
 
 @pytest.mark.parametrize("algorithm", utils.HASHERS.keys())
 def test_generic_algorithm(algorithm):
-    assert f'integrity="{algorithm}-' in templatetags.sri("index.css", algorithm)
-    assert f'integrity="{algorithm}-' in templatetags.sri("index.js", algorithm)
-
-
-def test_js():
-    assert (
-        templatetags.sri_js("index.js")
-        == '<script type="text/javascript" src="/static/index.js" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" crossorigin="anonymous"></script>'
-    )
-
-
-def test_css():
-    assert (
-        templatetags.sri_css("index.css")
-        == '<link rel="stylesheet" type="text/css" href="/static/index.css" integrity="sha256-fsqAKvNYgo9VQgSc4rD93SiW/AjKFwLtWlPi6qviBxY=" crossorigin="anonymous" />'
-    )
-
-
-def test_generic():
-    assert templatetags.sri_js("index.js") == templatetags.sri("index.js")
-    assert templatetags.sri_css("index.css") == templatetags.sri("index.css")
+    assert f'integrity="{algorithm}-' in templatetags.sri_static("index.css", algorithm)
+    assert f'integrity="{algorithm}-' in templatetags.sri_static("index.js", algorithm)
 
 
 def test_get_static_path():
@@ -105,14 +64,11 @@ def test_integrity(algorithm):
     assert integrity.startswith(algorithm)
 
 
-@pytest.mark.parametrize(
-    "tag", [templatetags.sri, templatetags.sri_css, templatetags.sri_js]
-)
-def test_disable_sri(tag):
+def test_disable_sri():
     original_value = templatetags.USE_SRI
     try:
         templatetags.USE_SRI = False
-        assert "integrity" not in tag("index.js")
+        assert "integrity" not in templatetags.sri_static("index.js")
     finally:
         templatetags.USE_SRI = original_value
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -79,3 +79,21 @@ def test_disable_sri(file):
 @pytest.mark.parametrize("file", TEST_FILES)
 def test_sri_integrity(algorithm, file):
     assert templatetags.sri_integrity(file, algorithm).startswith(f"{algorithm}-")
+
+
+@pytest.mark.parametrize("file", TEST_FILES)
+def test_unknown_algorithm(file):
+    with pytest.raises(KeyError) as e:
+        utils.calculate_integrity(file, "md5")
+    assert e.value.args[0] == "md5"
+
+
+def test_unknown_extension():
+    with pytest.raises(KeyError) as e:
+        templatetags.sri_static("index.md", utils.DEFAULT_ALGORITHM)
+    assert e.value.args[0] == "md"
+
+
+def test_missing_file():
+    with pytest.raises(FileNotFoundError):
+        templatetags.sri_static("foo.js", utils.DEFAULT_ALGORITHM)


### PR DESCRIPTION
Simplify the use of the API so it's easier to use, and makes more sense.

- Only expose the genric SRI tag, now under the name `sri_static`
- Expose the raw integrity calculation method in module
- Improve tests
- Update README + add more details
- Rename integrity tag to also have `_static` suffix