### PR TITLE
Use Django's file finder rather than custom implemented

### DIFF
--- a/sri/utils.py
+++ b/sri/utils.py
@@ -3,7 +3,7 @@ import hashlib
 from functools import lru_cache
 
 from django.conf import settings
-from django.utils._os import safe_join
+from django.contrib.staticfiles.finders import find as find_static_file
 
 HASHERS = {"sha256": hashlib.sha256, "sha384": hashlib.sha384, "sha512": hashlib.sha512}
 DEFAULT_ALGORITHM = getattr(settings, "SRI_ALGORITHM", "sha256")
@@ -24,7 +24,10 @@ def get_static_path(path: str) -> str:
     """
     Resolves a path commonly passed to `{% static %}` into a filesystem path
     """
-    return safe_join(settings.STATIC_ROOT, path)
+    static_file_path = find_static_file(path)
+    if static_file_path is None:
+        raise FileNotFoundError(path)
+    return static_file_path
 
 
 def calculate_integrity(path: str, algorithm: str = DEFAULT_ALGORITHM) -> str:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,7 +2,13 @@ import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-INSTALLED_APPS = ["django.contrib.staticfiles", "sri", "tests"]
+INSTALLED_APPS = [
+    "django.contrib.staticfiles",
+    "sri",
+    "tests",
+    "django.contrib.admin",
+    "django.contrib.contenttypes",
+]
 
 TEMPLATES = [
     {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ from django.template.loader import render_to_string
 from sri import utils
 from sri.templatetags import sri as templatetags
 
-TEST_FILES = ["index.css", "index.js"]
+TEST_FILES = ["index.css", "index.js", "admin/js/core.js"]
 
 
 def test_simple_template():
@@ -42,7 +42,8 @@ def test_generic_algorithm(algorithm, file):
 @pytest.mark.parametrize("file", TEST_FILES)
 def test_get_static_path(file):
     file_path = utils.get_static_path(file)
-    assert file_path == os.path.abspath(f"tests/static/{file}")
+    if "site-packages" not in file_path:
+        assert file_path == os.path.abspath(f"tests/static/{file}")
     assert os.path.isfile(file_path)
 
 
@@ -99,3 +100,7 @@ def test_unknown_extension():
 def test_missing_file():
     with pytest.raises(FileNotFoundError):
         templatetags.sri_static("foo.js", utils.DEFAULT_ALGORITHM)
+
+
+def test_app_file():
+    templatetags.sri_static("admin/js/core.js", utils.DEFAULT_ALGORITHM)


### PR DESCRIPTION
Fixes https://github.com/RealOrangeOne/django-sri/issues/61

Files don't have to live in `STATIC_ROOT` (and generally won't).

This also has the benefit of allowing it to be used for 3rd-party static files, like those from installed apps.