### PR TITLE
Add support for attrs and update output format

### DIFF
--- a/sri/templatetags/sri.py
+++ b/sri/templatetags/sri.py
@@ -37,12 +37,26 @@ def format_attrs(*simple_attrs, **complex_attrs) -> str:
 
 def sri_js(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
     complex_attrs.setdefault("src", static(path))
-    return mark_safe(f"<script{format_attrs(*simple_attrs, **complex_attrs)}></script>")
+    return script_tag(path, *simple_attrs, **complex_attrs)
 
 
 def sri_css(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
     complex_attrs.setdefault("rel", "stylesheet")
     complex_attrs.setdefault("type", "text/css")
+    return link_tag(path, *simple_attrs, **complex_attrs)
+
+
+def sri_font(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
+    complex_attrs.setdefault("rel", "stylesheet")
+    complex_attrs.setdefault("type", "text/css")
+    return link_tag(path, *simple_attrs, **complex_attrs)
+
+
+def script_tag(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
+    return mark_safe(f"<script{format_attrs(*simple_attrs, **complex_attrs)}></script>")
+
+
+def link_tag(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
     complex_attrs.setdefault("href", static(path))
     return mark_safe(f"<link{format_attrs(*simple_attrs, **complex_attrs)}>")
 
@@ -55,7 +69,7 @@ def sri_static(
     path: str, *simple_attrs: str, algorithm: str | None = None, **complex_attrs: str
 ) -> str:
     extension = os.path.splitext(path)[1][1:]
-    sri_method = EXTENSIONS[extension]
+    sri_method = EXTENSIONS.get(extension, link_tag)
     if USE_SRI:
         complex_attrs.setdefault("crossorigin", "anonymous")
         complex_attrs["integrity"] = sri_integrity_static(path, algorithm)

--- a/sri/templatetags/sri.py
+++ b/sri/templatetags/sri.py
@@ -36,7 +36,6 @@ def format_attrs(*simple_attrs, **complex_attrs) -> str:
 
 
 def sri_js(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
-    complex_attrs.setdefault("src", static(path))
     return script_tag(path, *simple_attrs, **complex_attrs)
 
 
@@ -46,13 +45,8 @@ def sri_css(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
     return link_tag(path, *simple_attrs, **complex_attrs)
 
 
-def sri_font(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
-    complex_attrs.setdefault("rel", "stylesheet")
-    complex_attrs.setdefault("type", "text/css")
-    return link_tag(path, *simple_attrs, **complex_attrs)
-
-
 def script_tag(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
+    complex_attrs.setdefault("src", static(path))
     return mark_safe(f"<script{format_attrs(*simple_attrs, **complex_attrs)}></script>")
 
 
@@ -66,7 +60,7 @@ EXTENSIONS = {"js": sri_js, "css": sri_css}
 
 @register.simple_tag
 def sri_static(
-    path: str, *simple_attrs: str, algorithm: str | None = None, **complex_attrs: str
+    path: str, *simple_attrs: str, algorithm: str = DEFAULT_ALGORITHM.value, **complex_attrs: str
 ) -> str:
     extension = os.path.splitext(path)[1][1:]
     sri_method = EXTENSIONS.get(extension, link_tag)
@@ -77,6 +71,6 @@ def sri_static(
 
 
 @register.simple_tag
-def sri_integrity_static(path: str, algorithm: str | None = None) -> str:
-    algorithm_type = Algorithm(algorithm or DEFAULT_ALGORITHM)
+def sri_integrity_static(path: str, algorithm: str = DEFAULT_ALGORITHM.value) -> str:
+    algorithm_type = Algorithm(algorithm)
     return calculate_integrity_of_static(path, algorithm_type)

--- a/sri/templatetags/sri.py
+++ b/sri/templatetags/sri.py
@@ -11,13 +11,12 @@ from django.utils.safestring import mark_safe
 from sri.algorithm import DEFAULT_ALGORITHM, Algorithm
 from sri.integrity import calculate_integrity_of_static
 
-
 USE_SRI = getattr(settings, "USE_SRI", not settings.DEBUG)
 
 register = template.Library()
 
 
-def format_attrs(*simple_attrs, **complex_attrs) -> str:
+def format_attrs(*empty_tag_attrs, **extra_tag_attrs) -> str:
     """
     Flatten and format list and dict params.
 
@@ -28,31 +27,33 @@ def format_attrs(*simple_attrs, **complex_attrs) -> str:
         ' href="/" rel="stylesheet"'
 
     """
-    complex = flatatt(complex_attrs)
-    if simple_attrs:
-        simple = " ".join(simple_attrs)
-        return f"{complex} {simple}".rstrip()
-    return complex.rstrip()
+    extra_attrs = flatatt(extra_tag_attrs)
+    if empty_tag_attrs:
+        empty_attrs = " ".join(empty_tag_attrs)
+        return f"{extra_attrs} {empty_attrs}".rstrip()
+    return extra_attrs.rstrip()
 
 
-def sri_js(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
-    return script_tag(path, *simple_attrs, **complex_attrs)
+def sri_js(path: str, *empty_tag_attrs: str, **extra_tag_attrs: str) -> str:
+    return script_tag(path, *empty_tag_attrs, **extra_tag_attrs)
 
 
-def sri_css(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
-    complex_attrs.setdefault("rel", "stylesheet")
-    complex_attrs.setdefault("type", "text/css")
-    return link_tag(path, *simple_attrs, **complex_attrs)
+def sri_css(path: str, *empty_tag_attrs: str, **extra_tag_attrs: str) -> str:
+    extra_tag_attrs.setdefault("rel", "stylesheet")
+    extra_tag_attrs.setdefault("type", "text/css")
+    return link_tag(path, *empty_tag_attrs, **extra_tag_attrs)
 
 
-def script_tag(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
-    complex_attrs.setdefault("src", static(path))
-    return mark_safe(f"<script{format_attrs(*simple_attrs, **complex_attrs)}></script>")
+def script_tag(path: str, *empty_tag_attrs: str, **extra_tag_attrs: str) -> str:
+    extra_tag_attrs.setdefault("src", static(path))
+    return mark_safe(
+        f"<script{format_attrs(*empty_tag_attrs, **extra_tag_attrs)}></script>"
+    )
 
 
-def link_tag(path: str, *simple_attrs: str, **complex_attrs: str) -> str:
-    complex_attrs.setdefault("href", static(path))
-    return mark_safe(f"<link{format_attrs(*simple_attrs, **complex_attrs)}>")
+def link_tag(path: str, *empty_tag_attrs: str, **extra_tag_attrs: str) -> str:
+    extra_tag_attrs.setdefault("href", static(path))
+    return mark_safe(f"<link{format_attrs(*empty_tag_attrs, **extra_tag_attrs)}>")
 
 
 EXTENSIONS = {"js": sri_js, "css": sri_css}
@@ -60,14 +61,17 @@ EXTENSIONS = {"js": sri_js, "css": sri_css}
 
 @register.simple_tag
 def sri_static(
-    path: str, *simple_attrs: str, algorithm: str = DEFAULT_ALGORITHM.value, **complex_attrs: str
+    path: str,
+    *empty_tag_attrs: str,
+    algorithm: str = DEFAULT_ALGORITHM.value,
+    **extra_tag_attrs: str,
 ) -> str:
     extension = os.path.splitext(path)[1][1:]
     sri_method = EXTENSIONS.get(extension, link_tag)
     if USE_SRI:
-        complex_attrs.setdefault("crossorigin", "anonymous")
-        complex_attrs["integrity"] = sri_integrity_static(path, algorithm)
-    return sri_method(path, *simple_attrs, **complex_attrs)
+        extra_tag_attrs.setdefault("crossorigin", "anonymous")
+        extra_tag_attrs["integrity"] = sri_integrity_static(path, algorithm)
+    return sri_method(path, *empty_tag_attrs, **extra_tag_attrs)
 
 
 @register.simple_tag

--- a/tests/static/index.woff2
+++ b/tests/static/index.woff2
@@ -1,0 +1,1 @@
+/* this is a fake font file */

--- a/tests/templates/algorithms.html
+++ b/tests/templates/algorithms.html
@@ -1,5 +1,9 @@
 {% load sri %}
-
-{% sri_static "index.js" "sha384" %}
-
-{% sri_static "index.css" "sha512" %}
+<!DOCTYPE html>
+<html lang="en"></html>
+    <head>
+        <title>Simple test page</title>
+        {% sri_static "index.js" algorithm="sha384" %}
+        {% sri_static "index.css" algorithm="sha512" %}
+    </head>
+</html>

--- a/tests/templates/complex.html
+++ b/tests/templates/complex.html
@@ -4,5 +4,6 @@
     <head>
         <title>Complex test page</title>
         {% sri_static "index.js" 'defer' 'async'%}
+        {% sri_static "index.woff2" preload as="font" %}
     </head>
 </html>

--- a/tests/templates/complex.html
+++ b/tests/templates/complex.html
@@ -1,0 +1,8 @@
+{% load sri %}
+<!DOCTYPE html>
+<html lang="en"></html>
+    <head>
+        <title>Complex test page</title>
+        {% sri_static "index.js" 'defer' 'async'%}
+    </head>
+</html>

--- a/tests/templates/simple.html
+++ b/tests/templates/simple.html
@@ -1,5 +1,9 @@
 {% load sri %}
-
-{% sri_static "index.js" %}
-
-{% sri_static "index.css" %}
+<!DOCTYPE html>
+<html lang="en"></html>
+    <head>
+        <title>Simple test page</title>
+        {% sri_static "index.js" %}
+        {% sri_static "index.css" %}
+    </head>
+</html>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,8 +9,8 @@ from django.template.loader import render_to_string
 from django.test import override_settings
 
 import sri
-from sri.templatetags import sri as templatetags
 from sri.algorithm import DEFAULT_ALGORITHM
+from sri.templatetags import sri as templatetags
 
 TEST_FILES = ["index.css", "index.js", "admin/js/core.js"]
 
@@ -194,7 +194,7 @@ def test_default_storage(file):
 
 
 @pytest.mark.parametrize(
-    "simple,complex,output",
+    "empty,extra,output",
     [
         ([], {}, ""),
         (["defer"], {}, " defer"),
@@ -203,6 +203,6 @@ def test_default_storage(file):
         (["defer"], {"type": "text/javascript"}, ' type="text/javascript" defer'),
     ],
 )
-def test_format_attrs(simple, complex, output: str) -> None:
-    elem = templatetags.format_attrs(*simple, **complex)
+def test_format_attrs(empty, extra, output: str) -> None:
+    elem = templatetags.format_attrs(*empty, **extra)
     assert elem == output, elem

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,6 +10,7 @@ from django.test import override_settings
 
 import sri
 from sri.templatetags import sri as templatetags
+from sri.algorithm import DEFAULT_ALGORITHM
 
 TEST_FILES = ["index.css", "index.js", "admin/js/core.js"]
 
@@ -59,6 +60,11 @@ def test_algorithms_template():
 def test_generic_algorithm(algorithm, file):
     val = templatetags.sri_integrity_static(file, algorithm)
     assert val.startswith(f"{algorithm.value}-"), val
+
+
+def test_default_algorithm():
+    val = templatetags.sri_integrity_static("index.js")
+    assert val.startswith(f"{DEFAULT_ALGORITHM.value}-"), val
 
 
 @pytest.mark.parametrize("file", TEST_FILES)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -36,6 +36,10 @@ def test_complex_template():
         '<script crossorigin="anonymous" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" src="/static/index.js" defer async></script>'
         in rendered
     )
+    assert (
+        '<link as="font" crossorigin="anonymous" href="/static/index.woff2" integrity="sha256-hWU2c2zzSsvKYN7tGMnt3t3Oj7GwQZB2aLRhCWYbFSE=">'
+        in rendered
+    ), rendered
 
 
 def test_algorithms_template():
@@ -113,12 +117,6 @@ def test_unknown_algorithm(file):
     with pytest.raises(ValueError) as e:
         templatetags.sri_static(file, algorithm="md5")
     assert e.value.args[0] == "'md5' is not a valid Algorithm"
-
-
-def test_unknown_extension():
-    with pytest.raises(KeyError) as e:
-        templatetags.sri_static("index.md")
-    assert e.value.args[0] == "md"
 
 
 def test_missing_file():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -21,11 +21,19 @@ def setup_function(*_):
 def test_simple_template():
     rendered = render_to_string("simple.html")
     assert (
-        '<script crossorigin="anonymous" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" src="/static/index.js" type="text/javascript"></script>'
+        '<script crossorigin="anonymous" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" src="/static/index.js"></script>'
         in rendered
     )
     assert (
-        '<link crossorigin="anonymous" href="/static/index.css" integrity="sha256-fsqAKvNYgo9VQgSc4rD93SiW/AjKFwLtWlPi6qviBxY=" rel="stylesheet" type="text/css"/>'
+        '<link crossorigin="anonymous" href="/static/index.css" integrity="sha256-fsqAKvNYgo9VQgSc4rD93SiW/AjKFwLtWlPi6qviBxY=" rel="stylesheet" type="text/css">'
+        in rendered
+    )
+
+
+def test_complex_template():
+    rendered = render_to_string("complex.html")
+    assert (
+        '<script crossorigin="anonymous" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" src="/static/index.js" defer async></script>'
         in rendered
     )
 
@@ -33,11 +41,11 @@ def test_simple_template():
 def test_algorithms_template():
     rendered = render_to_string("algorithms.html")
     assert (
-        '<script crossorigin="anonymous" integrity="sha384-dExnf54EbXTQ1VmweBEJRWX3MPT4xeDV5p71GIX2hpvV+8B/kzo3SObynuveYt9w" src="/static/index.js" type="text/javascript"></script>'
+        '<script crossorigin="anonymous" integrity="sha384-dExnf54EbXTQ1VmweBEJRWX3MPT4xeDV5p71GIX2hpvV+8B/kzo3SObynuveYt9w" src="/static/index.js"></script>'
         in rendered
     )
     assert (
-        '<link crossorigin="anonymous" href="/static/index.css" integrity="sha512-7v9G7AKwpjnlEYhw9GdXu/9G8bq0PqM427/QmgH2TufqEUcjsANEoyCoOkpV8TBCnbQigwNKpMaZNskJG8Ejdw==" rel="stylesheet" type="text/css"/>'
+        '<link crossorigin="anonymous" href="/static/index.css" integrity="sha512-7v9G7AKwpjnlEYhw9GdXu/9G8bq0PqM427/QmgH2TufqEUcjsANEoyCoOkpV8TBCnbQigwNKpMaZNskJG8Ejdw==" rel="stylesheet" type="text/css">'
         in rendered
     )
 
@@ -45,7 +53,8 @@ def test_algorithms_template():
 @pytest.mark.parametrize("algorithm", sri.Algorithm)
 @pytest.mark.parametrize("file", TEST_FILES)
 def test_generic_algorithm(algorithm, file):
-    assert f'integrity="{algorithm.value}-' in templatetags.sri_static(file, algorithm)
+    val = templatetags.sri_integrity_static(file, algorithm)
+    assert val.startswith(f"{algorithm.value}-"), val
 
 
 @pytest.mark.parametrize("file", TEST_FILES)
@@ -102,23 +111,23 @@ def test_sri_integrity_static(algorithm, file):
 @pytest.mark.parametrize("file", TEST_FILES)
 def test_unknown_algorithm(file):
     with pytest.raises(ValueError) as e:
-        templatetags.sri_static(file, "md5")
+        templatetags.sri_static(file, algorithm="md5")
     assert e.value.args[0] == "'md5' is not a valid Algorithm"
 
 
 def test_unknown_extension():
     with pytest.raises(KeyError) as e:
-        templatetags.sri_static("index.md", sri.algorithm.DEFAULT_ALGORITHM)
+        templatetags.sri_static("index.md")
     assert e.value.args[0] == "md"
 
 
 def test_missing_file():
     with pytest.raises(FileNotFoundError):
-        templatetags.sri_static("foo.js", sri.algorithm.DEFAULT_ALGORITHM)
+        templatetags.sri_static("foo.js")
 
 
 def test_app_file():
-    templatetags.sri_static("admin/js/core.js", sri.algorithm.DEFAULT_ALGORITHM)
+    templatetags.sri_static("admin/js/core.js")
 
 
 def test_uses_default_cache():
@@ -178,3 +187,18 @@ def test_default_storage(file):
     # will fail as the path returned will be the source path
     # and not the destination path.
     assert str(file_path).startswith(settings.STATIC_ROOT)
+
+
+@pytest.mark.parametrize(
+    "simple,complex,output",
+    [
+        ([], {}, ""),
+        (["defer"], {}, " defer"),
+        (["defer", "async"], {}, " defer async"),
+        ([], {"type": "text/javascript"}, ' type="text/javascript"'),
+        (["defer"], {"type": "text/javascript"}, ' type="text/javascript" defer'),
+    ],
+)
+def test_format_attrs(simple, complex, output: str) -> None:
+    elem = templatetags.format_attrs(*simple, **complex)
+    assert elem == output, elem


### PR DESCRIPTION
This PR is for reference only - as I don't anticipate it being merged. We have forked the repo and will pin to our version as we want to have a drop-in replacement for `static` that covers all of our use cases.

The event that triggered this change was a critical failure on our CI environment where we do not have all of our static content (as it requires a frontend build step that is not part of the backend test suite). This caused the test suite to fail because we were using the `sri_integrity_static` tag in templates, which is still called when `USE_SRI` is False (which it is in testing).

Updating `sri_integrity_static` to _not_ run when `USE_SRI` is False doesn't make sense, as if you are calling it explicitly then presumably you **do** want it to run. 🤔 

The root cause of this is that we were building output elements that `django-sri` doesn't support (`defer`, `async` etc.) In addition, the W3C HTML validator didn't like the output: 

<img width="919" alt="Screenshot 2022-11-23 at 11 07 44" src="https://user-images.githubusercontent.com/200944/203531973-84b63152-d003-4192-b647-c9132bf5e84e.png">

I started by making a minimal change to the output, but tbh I was bending the existing code too far, and it was becoming overly complex to support the existing use cases along with what we wanted to do.

In this version, we can support 'simple' tag attributes (`defer`, `async` etc) as well as 'complex' attributes (`type="text/javascript"`):

```html
{% load sri %}
<!DOCTYPE html>
<html lang="en"></html>
    <head>
        <title>Test page</title>
        {% sri_static "index.js" 'defer' 'async'%}
        <!-- <script crossorigin="anonymous" integrity="sha256-..." src="/static/index.js" defer async></script> -->
        {% sri_static "index.css"%}
        <!-- <link crossorigin="anonymous" href="/static/index.css" integrity="sha256-..." rel="stylesheet" type="text/css"> -->
    </head>
</html>
```
```