### PR TITLE
Fix issue in get_static_path

### DIFF
--- a/sri/utils.py
+++ b/sri/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -5,6 +6,8 @@ from django.contrib.staticfiles.finders import find as find_static_file
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.cache.backends.base import InvalidCacheBackendError
+
+logger = logging.getLogger(__name__)
 
 
 def get_static_path(path: str) -> Path:
@@ -14,10 +17,12 @@ def get_static_path(path: str) -> Path:
 
     if hasattr(staticfiles_storage, "stored_name"):
         path = staticfiles_storage.stored_name(path)
-        collected_file_path = staticfiles_storage.path(path)
-        if os.path.exists(collected_file_path):
-            return Path(collected_file_path)
 
+    collected_file_path = staticfiles_storage.path(path)
+    if os.path.exists(collected_file_path):
+        return Path(collected_file_path)
+
+    logger.debug("File not found in staticfiles_storage - checking source files")
     source_static_file_path = find_static_file(path)
     if source_static_file_path is not None:
         return Path(source_static_file_path)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -160,3 +160,21 @@ def test_manifest_storage(file):
     assert str(file_path).startswith(settings.STATIC_ROOT)
     assert not str(file_path).endswith(file)
     assert str(file_path).endswith(staticfiles_storage.stored_name(file))
+
+
+@override_settings(
+    STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage"
+)
+@pytest.mark.parametrize("file", TEST_FILES)
+def test_default_storage(file):
+    # Test for issue #70
+    call_command("collectstatic", interactive=False, clear=True, verbosity=0)
+
+    file_path = sri.utils.get_static_path(file)
+
+    assert file_path.exists()
+    assert file_path.is_file()
+    # If you rollback the changes outlined in issue #70, this
+    # will fail as the path returned will be the source path
+    # and not the destination path.
+    assert str(file_path).startswith(settings.STATIC_ROOT)


### PR DESCRIPTION
I think there is an indentation bug in the `get_static_path` function, where it is only using the `staticfiles_storage.path(path)` if the storage class has an attribute `stored_name` which is only the case with `ManifestStaticFilesStorage` (and subclasses thereof).

