### PR TITLE
hotfix for DEBUG=True and USE_SRI=True and ManifestStaticFilesStorage

### DIFF
--- a/sri/utils.py
+++ b/sri/utils.py
@@ -1,13 +1,11 @@
-import logging
 import os
 from pathlib import Path
 
+from django.conf import settings
 from django.contrib.staticfiles.finders import find as find_static_file
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.cache.backends.base import InvalidCacheBackendError
-
-logger = logging.getLogger(__name__)
 
 
 def get_static_path(path: str) -> Path:
@@ -15,14 +13,12 @@ def get_static_path(path: str) -> Path:
     Resolves a path commonly passed to `{% static %}` into a filesystem path
     """
 
-    if hasattr(staticfiles_storage, "stored_name"):
+    if (not settings.DEBUG) and hasattr(staticfiles_storage, "stored_name"):
         path = staticfiles_storage.stored_name(path)
+        collected_file_path = staticfiles_storage.path(path)
+        if os.path.exists(collected_file_path):
+            return Path(collected_file_path)
 
-    collected_file_path = staticfiles_storage.path(path)
-    if os.path.exists(collected_file_path):
-        return Path(collected_file_path)
-
-    logger.debug("File not found in staticfiles_storage - checking source files")
     source_static_file_path = find_static_file(path)
     if source_static_file_path is not None:
         return Path(source_static_file_path)

--- a/sri/utils.py
+++ b/sri/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -7,6 +8,8 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.cache.backends.base import InvalidCacheBackendError
 
+logger = logging.getLogger(__name__)
+
 
 def get_static_path(path: str) -> Path:
     """
@@ -15,10 +18,12 @@ def get_static_path(path: str) -> Path:
 
     if (not settings.DEBUG) and hasattr(staticfiles_storage, "stored_name"):
         path = staticfiles_storage.stored_name(path)
-        collected_file_path = staticfiles_storage.path(path)
-        if os.path.exists(collected_file_path):
-            return Path(collected_file_path)
 
+    collected_file_path = staticfiles_storage.path(path)
+    if os.path.exists(collected_file_path):
+        return Path(collected_file_path)
+
+    logger.debug("File not found in staticfiles_storage - checking source files")
     source_static_file_path = find_static_file(path)
     if source_static_file_path is not None:
         return Path(source_static_file_path)


### PR DESCRIPTION
Hello,

I use Django version 3.2.16 and I use the _ManifestStaticFilesStorage_ method for cache busting. Today I ran into a problem in the development environment (DEBUG=True).
The hash value calculated for some static files using _**{% sri_static %}**_ was not equal to their actual hash value, and this caused the following problem:
**_Failed to find a valid digest in the 'integrity' attribute for resource!_**

By debugging the library source code line by line, I reached the _get_static_path()_ function. In this function, it is checked that if _staticfiles_storage_ has _stored_name_ attribute then the path of the file is obtained from the _staticfiles_storage_ object, but because we are in the development environment, in fact, the wrong file is selected and as a result, the hash calculated for the file is different from the hash of the served file, And this will cause problems. To solve this problem, I added a condition to check DEBUG Mode to the _get_static_path()_ function and the problem is solved!

Of course, another thing that can be done to solve this problem is to use _ManifestStaticFilesStorage_ only for the deployment environment. But keep in mind that many people use _ManifestStaticFilesStorage_ to prevent unwanted errors during deployment and _collectstatic_ because by using it they can find out if they have a missing static file or not!