### PR TITLE
Use `hashlib.file_digest`

### DIFF
--- a/sri/hashers.py
+++ b/sri/hashers.py
@@ -21,13 +21,16 @@ def calculate_hash(path: Path, algorithm: Algorithm) -> str:
     file_hash = cache.get(cache_key)
     if file_hash is None:
         # Cache miss, do the calculation
-        hasher = HASHERS[algorithm]()
         with path.open("rb") as f:
-            while True:
-                data = f.read(READ_BUFFER_SIZE)
-                if not data:
-                    break
-                hasher.update(data)
+            if hasattr(hashlib, "file_digest"):
+                hasher = hashlib.file_digest(f, HASHERS[algorithm])
+            else:
+                hasher = HASHERS[algorithm]()
+                while True:
+                    data = f.read(READ_BUFFER_SIZE)
+                    if not data:
+                        break
+                    hasher.update(data)
         file_hash = base64.b64encode(hasher.digest()).decode()
         cache.set(cache_key, file_hash)
     return file_hash

--- a/sri/hashers.py
+++ b/sri/hashers.py
@@ -12,7 +12,7 @@ HASHERS = {
     Algorithm.SHA512: hashlib.sha512,
 }
 
-READ_BUFFER_SIZE = 65536  # 64k
+READ_BUFFER_SIZE = 2**18  # 256k - matches `hashlib.file_digest`
 
 
 def calculate_hash(path: Path, algorithm: Algorithm) -> str:


### PR DESCRIPTION
This implementation is likely faster / more efficient than ours.

It's only supported on Python 3.11, so requires a check for its existence. 