### PR TITLE
Add support for Jinja2

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,7 @@ calculate_integrity_of_static("index.js", Algorithm.SHA512)  # "sha512-..."
 Yes. `django-sri` outputs the static file URL in the same way the builtin `static` template tag does. This means the correct cachebusted URLs are output.
 
 When using a manifest `STATICFILES_STORAGE`, `django-sri` will automatically retrieve the hashed and post-processed file as opposed to the original.
+
+### `jinja2`
+
+Support for `jinja2` templates is provided using the `sri.jinja2.sri` extension, which adds the documented Django template tags as global functions. These functions work identically to the Django template versions.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ mypy==1.14.1
 pytest==8.3.4
 pytest-django==4.9.0
 pytest-cov==6.0.0
+jinja2

--- a/sri/jinja2.py
+++ b/sri/jinja2.py
@@ -1,0 +1,16 @@
+from jinja2 import Environment
+from jinja2.ext import Extension
+
+from sri.templatetags.sri import sri_integrity_static, sri_static
+
+
+class SRIExtension(Extension):
+    def __init__(self, environment: Environment) -> None:
+        super().__init__(environment)
+
+        environment.globals["sri_static"] = sri_static
+        environment.globals["sri_integrity_static"] = sri_integrity_static
+
+
+# Shorthand
+sri = SRIExtension

--- a/tests/jinja2/complex.j2
+++ b/tests/jinja2/complex.j2
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en"></html>
+    <head>
+        <title>Complex test page</title>
+        {{ sri_static("index.js", 'defer', 'async') }}
+        {{ sri_static("index.woff2", "preload", as="font") }}
+    </head>
+</html>

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,6 +17,12 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {},
     },
+    {
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {"environment": "tests.utils.create_jinja2_environment"},
+    },
 ]
 
 SECRET_KEY = "abcde12345"

--- a/tests/templates/complex.html
+++ b/tests/templates/complex.html
@@ -3,7 +3,7 @@
 <html lang="en"></html>
     <head>
         <title>Complex test page</title>
-        {% sri_static "index.js" 'defer' 'async'%}
-        {% sri_static "index.woff2" preload as="font" %}
+        {% sri_static "index.js" 'defer' 'async' %}
+        {% sri_static "index.woff2" "preload" as="font" %}
     </head>
 </html>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -39,7 +39,7 @@ def test_complex_template():
         in rendered
     )
     assert (
-        '<link as="font" crossorigin="anonymous" href="/static/index.woff2" integrity="sha256-hWU2c2zzSsvKYN7tGMnt3t3Oj7GwQZB2aLRhCWYbFSE=">'
+        '<link as="font" crossorigin="anonymous" href="/static/index.woff2" integrity="sha256-hWU2c2zzSsvKYN7tGMnt3t3Oj7GwQZB2aLRhCWYbFSE=" preload>'
         in rendered
     ), rendered
 
@@ -52,6 +52,18 @@ def test_algorithms_template():
     )
     assert (
         '<link crossorigin="anonymous" href="/static/index.css" integrity="sha512-7v9G7AKwpjnlEYhw9GdXu/9G8bq0PqM427/QmgH2TufqEUcjsANEoyCoOkpV8TBCnbQigwNKpMaZNskJG8Ejdw==" rel="stylesheet" type="text/css">'
+        in rendered
+    )
+
+
+def test_jinja2_template():
+    rendered = render_to_string("complex.j2")
+    assert (
+        '<script crossorigin="anonymous" integrity="sha256-VROI/fAMCWgkTthVtzzvHtPkkxvpysdZbcqLdVMtwOI=" src="/static/index.js" defer async></script>'
+        in rendered
+    )
+    assert (
+        '<link as="font" crossorigin="anonymous" href="/static/index.woff2" integrity="sha256-hWU2c2zzSsvKYN7tGMnt3t3Oj7GwQZB2aLRhCWYbFSE=" preload>'
         in rendered
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,7 @@
+from jinja2 import Environment
+
+
+def create_jinja2_environment(**options):
+    env = Environment(**options)
+    env.add_extension("sri.jinja2.sri")
+    return env


### PR DESCRIPTION
Copy the existing template tags into an extension, so they can be accessed by `jinja2`.